### PR TITLE
Adicionando opção de Personalizar o tema 

### DIFF
--- a/css/theme-debates-anti-corrupcao.css
+++ b/css/theme-debates-anti-corrupcao.css
@@ -15,7 +15,10 @@ body {
   height: 100% !important;
 }
 #anti-corr .anti-corr-top {
+  /*
+  Desativando a imagem de fundo do CSS para funcionar de forma dinamica
   background: url("../images/anti-corrupcao/bck-anti-corrupcao.jpg") repeat #5d7987;
+  */
   padding: 0;
   margin: 0;
 }

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,67 @@
+<?php
+
+function debatepublico_customizer_register( $wp_customize ) {
+	
+	// Configurações cor de fundo
+	$wp_customize->add_setting( 'header_bgcolor' , array(
+	    'default'     => '#5d7987',
+	    'transport'   => 'postMessage',
+	) );
+	
+	// Configurações da imagem de fundo
+	$wp_customize->add_setting( 'header_image' , array(
+	    'default'     => get_stylesheet_directory_uri().'/images/anti-corrupcao/bck-anti-corrupcao.jpg',
+	    'transport'   => 'postMessage',
+	) );
+	
+	// Criando uma nova seção "Cabeçalho"
+	$wp_customize->add_section( 'debatepublico_banner' , array(
+	    'title'      => __( 'Cabeçalho', 'debatepublico' ),
+	    'priority'   => 30,
+	) );
+	
+	// Adicionando um controle de escolha de cor
+	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'header_color', array(
+		'label'        => __( 'Cor de Fundo', 'debatepublico' ),
+		'section'    => 'debatepublico_banner',
+		'settings'   => 'header_bgcolor',
+	) ) );
+	
+	// Adicionando um controle de escolha de imagem
+	$wp_customize->add_control( new WP_Customize_Image_Control( $wp_customize, 'header_image', array(
+		'label'        => __( 'Imagem de Fundo', 'debatepublico' ),
+		'section'    => 'debatepublico_banner',
+		'settings'   => 'header_image',
+	) ) );
+}
+
+// Adiciona ao registro de Personalizacão
+add_action( 'customize_register', 'debatepublico_customizer_register' );
+
+
+function debatepublico_customizer_live_preview()
+{
+	wp_enqueue_script( 
+		  'debatepublico-themecustomizer',
+		  get_stylesheet_directory_uri().'/js/theme-customizer.js',
+		  array( 'jquery','customize-preview' ),
+		  '',		//Versão
+		  true	//No rodapé
+	);
+}
+add_action( 'customize_preview_init', 'debatepublico_customizer_live_preview' );
+
+function debatepublico_customize_css() {
+	$bgimage = get_theme_mod('header_image', get_stylesheet_directory_uri().'/images/anti-corrupcao/bck-anti-corrupcao.jpg');
+?>
+	<style type="text/css">
+	    .anti-corr-top { 
+			 background-color:<?php echo get_theme_mod('header_bgcolor', '#5d7987'); ?>;
+			 <?php if ($bgimage != '') { ?>background: url(<?php echo $bgimage; ?>)<?php } ?>
+		 }
+	</style>
+<?php
+}
+add_action( 'wp_head', 'debatepublico_customize_css');
+
+?>

--- a/js/theme-customizer.js
+++ b/js/theme-customizer.js
@@ -1,0 +1,17 @@
+( function( $ ) {
+
+	//Atualizando a cor de fundo do cabeçalho
+	wp.customize( 'header_bgcolor', function( value ) {
+		value.bind( function( newval ) {
+			$('.anti-corr-top').css('background-color', newval );
+		} );
+	} );
+
+	// Atualizando a imagem de fundo do cabeçalho
+	wp.customize( 'header_image', function( value ) {
+		value.bind( function( newval ) {
+			$('.anti-corr-top').css('background', 'url('+newval+')' );
+		} );
+	} );	
+	
+} )( jQuery );


### PR DESCRIPTION
Permite escolher uma cor de fundo e uma imagem de fundo aparecendo na tela principal do
tema na área com a "logo" e "Participe, opine, ajude!"

(desafio de programação - Edital 6 - Consultor Desenvolvimento Web)
